### PR TITLE
Register did:safe

### DIFF
--- a/index.html
+++ b/index.html
@@ -3407,6 +3407,23 @@ address in the Author Links column, as this helps with maintenance.
         </tr>
         <tr>
           <td>
+            did:safe:
+          </td>
+          <td>
+            PROVISIONAL
+          </td>
+          <td>
+            Gnosis Safe
+          </td>
+          <td>
+            <a href="mailto:safe@gnosis.io">Gnosis Ltd.</a>
+          </td>
+          <td>
+            <a href="https://github.com/ceramicnetwork/CIP/issues/101">SAFE DID Method</a>
+          </td>
+        </tr>
+        <tr>
+          <td>
             did:san:
           </td>
           <td>


### PR DESCRIPTION
The SAFE DID is a new DID method created using the Ceramic network. It allows any [Gnosis Safe](https://gnosis-safe.io/) smart contract wallet on any EVM based blockchain to be used as a DID where the owners becomes the controller of the DID.